### PR TITLE
Add example for concatenating fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ http://geoservices.tamu.edu/Services/Geocode/WebService/GeocoderWebServiceHttpNo
 https://search.mapzen.com/v1/search?api_key=MY_API_KEY&text={{address}}
 ```
 
-Since this is just a Mustache template, we can also expand it to concatenate multiple fields:
+If your addresses are broken up into multiple columns (e.g. a street_address column, a city column, and a state column), you can use them all together in a URL template:
 
 ```
-https://maps.googleapis.com/maps/api/geocode/json?address={{address}},{{city}},{{state}}&key=MY_API_KEY
+https://maps.googleapis.com/maps/api/geocode/json?address={{street_address}},{{city}},{{state}}&key=MY_API_KEY
 ```
 
 #### `--handler [handler]`

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ http://geoservices.tamu.edu/Services/Geocode/WebService/GeocoderWebServiceHttpNo
 https://search.mapzen.com/v1/search?api_key=MY_API_KEY&text={{address}}
 ```
 
+Since this is just a Mustache template, we can also expand it to concatenate multiple fields:
+
+```
+https://maps.googleapis.com/maps/api/geocode/json?address={{address}},{{city}},{{state}}&key=MY_API_KEY
+```
+
 #### `--handler [handler]`
 
 What handler function to process the API response with.  Current built-in handlers are `"google"`, `"mapbox"`, `"mapzen"`, `"osm"`, and `"tamu"`. Contributions of handlers for other geocoders are welcome! You can define a custom handler when using this as a Node module (see below).


### PR DESCRIPTION
My CSV file has all the info the geocoder needs spread across multiple fields ("Address", "City", "State").

Haven't used Mustache in a minute, so I forgot the syntax for concatenating. This PR adds an example of that.