### PR TITLE
use querystring rather than mustache templates; support extra attributes in custom providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install -g csvgeocode
 Use it:
 
 ```
-$ csvgeocode path/to/input.csv path/to/output.csv --url "https://maps.googleapis.com/maps/api/geocode/json?address={{MY_ADDRESS_COLUMN_NAME}}&key=MY_API_KEY"
+$ csvgeocode path/to/input.csv path/to/output.csv --baseURL "https://maps.googleapis.com/maps/api/geocode/json" --defaultURLParams '{"key": "MY_API_KEY"}' --customURLParams '{"address": "MY_ADDRESS_COLUMN_NAME"}'
 ```
 
 If you don't specify an output file, the output will stream to stdout instead, so you can stream the result as an HTTP response or do something like:
@@ -32,29 +32,35 @@ $ csvgeocode path/to/input.csv [options] | grep "greppin for somethin"
 You can add extra options when running `csvgeocode`.  For example:
 
 ```
-$ csvgeocode input.csv output.csv --url "http://someurl.com/" --lat CALL_MY_LATITUDE_COLUMN_THIS_SPECIAL_NAME --delay 1000 --verbose
+$ csvgeocode input.csv output.csv --baseURL "http://someurl.com/" --lat CALL_MY_LATITUDE_COLUMN_THIS_SPECIAL_NAME --delay 1000 --verbose
 ```
 
-The only required option is `url`.  All others are optional.
+The only required option is `baseURL`.  All others are optional.
 
-#### `--url [url]` (REQUIRED)
+#### `--baseURL [baseurl]` (REQUIRED)
 
-A URL template with column names as [Mustache tags](http://mustache.github.io/), like:
+A Base URL without the query parameters.
 
-```
-http://api.tiles.mapbox.com/v4/geocode/mapbox.places/{{address}}.json?access_token=MY_API_KEY
+#### `--defaultURLParams [JSON static query parameters]`
+#### `--customURLParams [JSON dynamic query parameters]`
 
-https://maps.googleapis.com/maps/api/geocode/json?address={{address}}&key=MY_API_KEY
-
-http://geoservices.tamu.edu/Services/Geocode/WebService/GeocoderWebServiceHttpNonParsed_V04_01.aspx?apiKey=MY_API_KEY&version=4.01&streetAddress={{address}}&city={{city}}&state={{state}}
-
-https://search.mapzen.com/v1/search?api_key=MY_API_KEY&text={{address}}
-```
-
-If your addresses are broken up into multiple columns (e.g. a street_address column, a city column, and a state column), you can use them all together in a URL template:
+Examples:
 
 ```
-https://maps.googleapis.com/maps/api/geocode/json?address={{street_address}},{{city}},{{state}}&key=MY_API_KEY
+--baseURL 'http://api.tiles.mapbox.com/v4/geocode/mapbox.places/{{address}}.json'
+--defaultURLParams '{"access_token": "MY_API_KEY"}'
+
+--baseURL 'https://maps.googleapis.com/maps/api/geocode/json'
+--defaultURLParams '{"key": "MY_API_KEY"}'
+--customURLParams '{"address": "address"}'
+
+--baseURL 'http://geoservices.tamu.edu/Services/Geocode/WebService/GeocoderWebServiceHttpNonParsed_V04_01.aspx'
+--defaultURLParams '{"apiKey": "MY_API_KEY", "version": "4.01"}'
+--customURLParams  '{"streetAddress": "address", "city": "city", "state": "state"}'
+
+--baseURL 'https://search.mapzen.com/v1/search'
+--defaultURLParams '{"api_key": "MY_API_KEY"}'
+--customURLParams '{"text": "address"}'
 ```
 
 #### `--handler [handler]`
@@ -99,7 +105,7 @@ By default, if a lat/lng is already found in an input row, that will be kept.  I
 See extra output while csvgeocode is running.
 
 ```
-$ csvgeocode input.csv --url "MY_API_URL" --verbose
+$ csvgeocode input.csv --baseURL "MY_API_URL" --defaultURLParams '{"language": "en"}' --customURLParams '{"q": "query"}' --verbose
 160 Varick St,New York,NY
 SUCCESS
 
@@ -129,12 +135,24 @@ var csvgeocode = require("csvgeocode");
 
 //stream to stdout
 csvgeocode("path/to/input.csv",{
-    url: "MY_API_URL"
+    baseURL: "MY_API_URL",
+    defaultURLParams: {
+        language: 'en'
+    },
+    customURLParams: {
+        q: 'query'
+    }
   });
 
 //write to a file
 csvgeocode("path/to/input.csv","path/to/output.csv",{
-    url: "MY_API_URL"
+    baseURL: "MY_API_URL",
+    defaultURLParams: {
+        language: 'en'
+    },
+    customURLParams: {
+        q: 'query'
+    }
   });
 ```
 
@@ -142,7 +160,9 @@ You can add all the same options in a script, except for `verbose`.
 
 ```js
 var options = {
-  "url": "MY_API_URL",
+  "baseURL": "MY_API_URL",
+  "defaultURLParams": { language: 'en' },
+  "customURLParams": { q: 'query' },
   "lat": "MY_SPECIAL_LATITUDE_COLUMN_NAME",
   "lng": "MY_SPECIAL_LONGITUDE_COLUMN_NAME",
   "delay": 1000,
@@ -208,7 +228,9 @@ The handler function is passed the body of an API response and should either ret
 ```js
 
 csvgeocoder("input.csv",{
-  url: "MY_API_URL",
+  baseURL: "MY_API_URL",
+  defaultURLParams: { language: 'en' },
+  customURLParams: { q: 'query' },
   handler: customHandler
 });
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ You can use any basic geocoding service from within a Node script by supplying a
 
 The easiest way to see what a handler should look like is to look at [handlers.js](./src/handlers.js).
 
-The handler function is passed the body of an API response and should either return a string error message or an object with `lat` and `lng` properties.
+The handler function is passed the body of an API response and should either return a string error message or an object with `lat` and `lng` properties. Additional properties may be returned.
 
 ```js
 
@@ -239,7 +239,8 @@ function customHandler(body) {
   if (body.result) {
     return {
       lat: body.result.lat,
-      lng: body.result.lng
+      lng: body.result.lng,
+      id: body.result.id
     };
   }
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Examples:
 
 --baseURL 'https://maps.googleapis.com/maps/api/geocode/json'
 --defaultURLParams '{"key": "MY_API_KEY"}'
---customURLParams '{"address": "address"}'
+--customURLParams '{"address": ["address", "city", "state", "country"]}'
 
 --baseURL 'http://geoservices.tamu.edu/Services/Geocode/WebService/GeocoderWebServiceHttpNonParsed_V04_01.aspx'
 --defaultURLParams '{"apiKey": "MY_API_KEY", "version": "4.01"}'

--- a/src/csvgeocode.js
+++ b/src/csvgeocode.js
@@ -99,7 +99,13 @@ Geocoder.prototype.run = function(input,output,options) {
 
     var customURLParams = {};
     for (var k in options.customURLParams) {
-        customURLParams[k] = row[options.customURLParams[k]];
+        if (Array.isArray(options.customURLParams[k])) {
+            customURLParams[k] = options.customURLParams[k].map(function (i) {
+                return row[i];
+            }).join(', ');
+        } else {
+            customURLParams[k] = row[options.customURLParams[k]];
+        }
     }
     var url = render(options.baseURL, escape(row)) + "?" + querystring.stringify(extend(options.defaultURLParams, customURLParams));;
 

--- a/src/csvgeocode.js
+++ b/src/csvgeocode.js
@@ -8,6 +8,7 @@ var misc = require("./misc"),
     util = require("util"),
     render = require("mustache").render,
     csv = require("./csv"),
+    querystring = require('querystring'),
     EventEmitter = require("events").EventEmitter;
 
 module.exports = generate;
@@ -47,8 +48,8 @@ function generate(inFile,outFile,userOptions) {
     throw new TypeError("Invalid value for output.  Needs to be a string filename.");
   }
 
-  if (typeof options.url !== "string") {
-    throw new Error("'url' parameter is required.");
+  if (typeof options.baseURL !== "string") {
+    throw new Error("'baseURL' parameter is required.");
   }
 
   var geocoder = new Geocoder();
@@ -96,7 +97,11 @@ Geocoder.prototype.run = function(input,output,options) {
 
   function codeRow(row,cb) {
 
-    var url = render(options.url,escape(row));
+    var customURLParams = {};
+    for (var k in options.customURLParams) {
+        customURLParams[k] = row[options.customURLParams[k]];
+    }
+    var url = render(options.baseURL, escape(row)) + "?" + querystring.stringify(extend(options.defaultURLParams, customURLParams));;
 
     //Doesn't need geocoding
     if (!options.force && misc.isNumeric(row[options.lat]) && misc.isNumeric(row[options.lng])) {

--- a/src/csvgeocode.js
+++ b/src/csvgeocode.js
@@ -114,11 +114,17 @@ Geocoder.prototype.run = function(input,output,options) {
 
       row[options.lat] = cache[url].lat;
       row[options.lng] = cache[url].lng;
+      for (var k in cache[url]) {
+        if (k !== "lat" && k !== "lng") {
+          row[k] = cache[url][k];
+        }
+      }
 
       _this.emit("row",null,row);
       return cb(null,row);
 
     }
+
 
     request.get(url,function(err,response,body) {
     
@@ -167,6 +173,11 @@ Geocoder.prototype.run = function(input,output,options) {
 
       row[options.lat] = result.lat;
       row[options.lng] = result.lng;
+      for (var k in result) {
+        if (k !== "lat" && k !== "lng") {
+          row[k] = result[k];
+        }
+      }
 
       //Cache the result
       cache[url] = result;


### PR DESCRIPTION
Hi @veltman. Thanks for building this repository. I've made two changes which I wanted to share, but I don't think they are ready to be merged. So please feel free to close this PR or add your comments on if you think the intent is a good direction and if it warrants further work, or if you're not keen on integrating these changes (that's absolutely fine).

1. The first commit here uses `querystring` rather than mustache templates. I ran into a bug where if the mustache variable was in the query string and contained a `'` (apostrophe) the URL wouldn't be created correctly based on the template. Using the `querystring` module fixed that for me. But adds significant complexity to the user interface. ~~~It also drops support for concatenating columns in the URL. (fixed in latest commit)~~~

2. The second is for custom providers to return more than just `lat`, `lng`, such that any extra attributes returned are simply added to the output CSV.